### PR TITLE
Fix: Ensure 'ret' is defined (for strict mode).

### DIFF
--- a/examples/libs/THREE.WebAR.js
+++ b/examples/libs/THREE.WebAR.js
@@ -155,7 +155,7 @@ THREE.WebAR.getIndexFromScreenAndSeeThroughCameraOrientations = function(vrDispl
     THREE.WebAR.getIndexFromOrientation(seeThroughCameraOrientation);
   var screenOrientationIndex = 
     THREE.WebAR.getIndexFromOrientation(screenOrientation);
-  ret = screenOrientationIndex - seeThroughCameraOrientationIndex;
+  var ret = screenOrientationIndex - seeThroughCameraOrientationIndex;
   if (ret < 0) {
     ret += 4;
   }


### PR DESCRIPTION
Quick fix, since I'm using Browserify and all my code is under a `'use strict';` declaration. 